### PR TITLE
LUGG-714 - Adding permissions for site index

### DIFF
--- a/luggage_roles.views_default.inc
+++ b/luggage_roles.views_default.inc
@@ -215,7 +215,7 @@ function luggage_roles_views_default_views() {
   $handler->display->display_options['title'] = 'Site Index';
   $handler->display->display_options['use_ajax'] = TRUE;
   $handler->display->display_options['use_more_always'] = FALSE;
-  $handler->display->display_options['access']['type'] = 'none';
+  $handler->display->display_options['access']['type'] = 'perm';
   $handler->display->display_options['cache']['type'] = 'none';
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['exposed_form']['type'] = 'basic';


### PR DESCRIPTION
Changed access permissions for site index from to "permission-based."

To test:
* Pull down my changes
* Go to admin/structure/views/view/site_index
* Verify that the access settings are for "Permission | View published content"