### PR TITLE
LUGG-355 Added link to tutorials to admin menu

### DIFF
--- a/luggage_roles.module
+++ b/luggage_roles.module
@@ -21,6 +21,14 @@ function luggage_roles_menu() {
     'title' => 'Broken links',
     'type' => MENU_NORMAL_ITEM,
   );
+
+  $items['http://www.biology-it.iastate.edu/luggage_doc/guide'] = array(
+    'title' => t('Tutorials'),
+    'type' => MENU_NORMAL_ITEM,
+    'weight' => 50,
+    'access arguments' => array('access administration menu'),
+    'menu_name' => 'management',
+  );
   return $items;
 }
 


### PR DESCRIPTION
Added menu link to the administration menu.

To test:
- Pull down this branch
- Run a feature revert (just to be safe)
- Clear all caches
- Make sure you're logged in to your site
- Does the tutorial menu item appear?

Test to be sure that:
- Tutorial link appears in the right-most position in the admin menu
- The menu item does not show up for anonymous users
- The menu item goes to the correct path: http://www.biology-it.iastate.edu/luggage_doc/guide
- The menu item shows up for authenticated users that aren't admin